### PR TITLE
Allow files to be copied to master and agents

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,7 +23,13 @@
       * [run_command_on_master()](#run_command_on_master)
       * [run_command_on_agent()](#run_command_on_agent)
       * [run_dcos_command()](#run_dcos_command)
-    * Services
+    * File operations
+      * [copy_file()](#copy_file)
+      * [copy_file_to_master()](#copy_file_to_master)
+      * [copy_file_to_agent()](#copy_file_to_agent)
+      * [copy_file_from_master()](#copy_file_from_master)
+      * [copy_file_from_agent()](#copy_file_from_agent)
+    * Services and tasks
       * [get_service()](#get_service)
       * [get_service_framework_id()](#get_service_framework_id)
       * [get_service_task()](#get_service_task)
@@ -292,6 +298,102 @@ parameter | description | type | default
 result, error = run_dcos_command('package search jenkins --json')
 result_json = json.loads(result)
 print(result_json['packages'][0]['currentVersion'])
+```
+
+
+### copy_file()
+
+Copy a file via SCP.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**host** | the hostname or IP to copy the file to/from | str
+**file_path** | the local path to the file to be copied | str
+remote_path | the remote path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+action | 'put' (default) or 'get' | str | `put`
+
+##### *example usage*
+
+```python
+# Copy a datafile onto the Mesos master
+copy_file(master_ip(), '/var/data/datafile.txt')
+```
+
+
+### copy_file_to_master()
+
+Copy a file to the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**file_path** | the local path to the file to be copied | str
+remote_path | the remote path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile onto the Mesos master
+copy_file_to_master('/var/data/datafile.txt')
+```
+
+
+### copy_file_to_agent()
+
+Copy a file to a Mesos agent, proxied through the Mesos master.
+
+*This method uses the same parameters as [`copy_file()`](#copy_file)*
+
+
+### copy_file_from_master()
+
+Copy a file from the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**remote_path** | the remote path of the file to copy | str |
+file_path | the local path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile from the Mesos master
+copy_file_from_master('/var/data/datafile.txt')
+```
+
+
+### copy_file_from_agent()
+
+Copy a file from a Mesos agent, proxied through the Mesos master.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**host** | the hostname or IP to copy the file from | str
+**remote_path** | the remote path of the file to copy | str
+file_path | the local path to copy the file to | str | `.`
+username | the username used for SSH authentication | str | `core`
+key_path | the path to the SSH keyfile used for authentication | str | `None`
+
+##### *example usage*
+
+```python
+# Copy a datafile from an agent running Jenkins
+service_ips = get_service_ips('marathon', 'jenkins')
+for host in service_ips:
+    assert copy_file_from_agent(host, '/home/jenkins/datafile.txt')
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='shakedown',
           'dcoscli==0.4.4',
           'paramiko',
           'pytest',
+          'scp'
       ],
       entry_points="""
       [console_scripts]

--- a/shakedown/__init__.py
+++ b/shakedown/__init__.py
@@ -2,6 +2,7 @@ from shakedown.cli import *
 from shakedown.cli.helpers import *
 from shakedown.dcos import *
 from shakedown.dcos.command import *
+from shakedown.dcos.file import *
 from shakedown.dcos.package import *
 from shakedown.dcos.service import *
 

--- a/shakedown/dcos/file.py
+++ b/shakedown/dcos/file.py
@@ -1,0 +1,113 @@
+import os
+import scp
+import time
+
+from shakedown.dcos.helpers import *
+
+import shakedown
+
+
+def copy_file(
+        host,
+        file_path,
+        remote_path='.',
+        username='core',
+        key_path=None,
+        action='put'
+):
+    """ Copy a file via SCP, proxied through the mesos master
+
+        :param host: host or IP of the machine to execute the command on
+        :type host: str
+        :param file_path: the local path to the file to be copied
+        :type file_path: str
+        :param remote_path: the remote path to copy the file to
+        :type remote_path: str
+        :param username: SSH username
+        :type username: str
+        :param key_path: path to the SSH private key to use for SSH authentication
+        :type key_path: str
+
+        :return: True if successful, False otherwise
+        :rtype: bool
+    """
+
+    if not key_path:
+        key_path = shakedown.cli.ssh_key_file
+
+    key = validate_key(key_path)
+
+    transport = get_transport(host, username, key)
+    transport = start_transport(transport, username, key)
+
+    if transport.is_authenticated():
+        start = time.time()
+
+        channel = scp.SCPClient(transport)
+
+        if action == 'get':
+            print("\n{}scp {}:{} {}\n".format(shakedown.cli.helpers.fchr('>>'), host, remote_path, file_path))
+            channel.get(remote_path, file_path)
+        else:
+            print("\n{}scp {} {}:{}\n".format(shakedown.cli.helpers.fchr('>>'), file_path, host, remote_path))
+            channel.put(file_path, remote_path)
+
+        print(str(os.path.getsize(file_path)) + ' bytes copied in ' + str(round(time.time() - start, 2))  + ' seconds.')
+
+        channel.close()
+        transport.close()
+
+        return True
+    else:
+        print('error: unable to authenticate ' + username + '@' + host + ' with key ' + key_path)
+        return False
+
+
+def copy_file_to_master(
+        file_path,
+        remote_path='.',
+        username='core',
+        key_path=None
+):
+    """ Copy a file to the Mesos master
+    """
+
+    return copy_file(shakedown.master_ip(), file_path, remote_path, username, key_path)
+
+
+def copy_file_to_agent(
+        host,
+        file_path,
+        remote_path='.',
+        username='core',
+        key_path=None
+):
+    """ Copy a file to a Mesos agent, proxied through the master
+    """
+
+    return copy_file(host, file_path, remote_path, username, key_path)
+
+
+def copy_file_from_master(
+        remote_path,
+        file_path='.',
+        username='core',
+        key_path=None
+):
+    """ Copy a file to the Mesos master
+    """
+
+    return copy_file(shakedown.master_ip(), file_path, remote_path, username, key_path, 'get')
+
+
+def copy_file_from_agent(
+        host,
+        remote_path,
+        file_path='.',
+        username='core',
+        key_path=None
+):
+    """ Copy a file to a Mesos agent, proxied through the master
+    """
+
+    return copy_file(host, file_path, remote_path, username, key_path, 'get')

--- a/shakedown/dcos/helpers.py
+++ b/shakedown/dcos/helpers.py
@@ -1,0 +1,74 @@
+import os
+import paramiko
+import scp
+
+import shakedown
+
+
+def get_transport(host, username, key):
+    """ Create a transport object
+
+        :param host: the hostname to connect to
+        :type host: str
+        :param username: SSH username
+        :type username: str
+        :param key: key object used for authentication
+        :type key: paramiko.RSAKey
+
+        :return: a transport object
+        :rtype: paramiko.Transport
+    """
+
+    if host == shakedown.master_ip():
+        transport = paramiko.Transport(host)
+    else:
+        transport_master = paramiko.Transport(shakedown.master_ip())
+        transport_master = start_transport(transport_master, username, key)
+
+        if not transport_master.is_authenticated():
+           print('error: unable to authenticate ' + username + '@' + shakedown.master_ip() + ' with key ' + key_path)
+           return False
+
+        channel = transport_master.open_channel('direct-tcpip', (host, 22), ('127.0.0.1', 0))
+        transport = paramiko.Transport(channel)
+
+    return transport
+
+
+def start_transport(transport, username, key):
+    """ Begin a transport client and authenticate it
+
+        :param transport: the transport object to start
+        :type transport: paramiko.Transport
+        :param username: SSH username
+        :type username: str
+        :param key: key object used for authentication
+        :type key: paramiko.RSAKey
+
+        :return: the transport object passed
+        :rtype: paramiko.Transport
+    """
+
+    transport.start_client()
+    transport.auth_publickey(username, key)
+
+    return transport
+
+
+def validate_key(key_path):
+    """ Validate a key
+
+        :param key_path: path to a key to use for authentication
+        :type key_path: str
+
+        :return: key object used for authentication
+        :rtype: paramiko.RSAKey
+    """
+
+    key_path = os.path.expanduser(key_path)
+
+    if not os.path.isfile(key_path):
+        print('error: key not found: ' + key_path)
+        return False
+
+    return paramiko.RSAKey.from_private_key_file(key_path)

--- a/tests/acceptance/test_dcos_file.py
+++ b/tests/acceptance/test_dcos_file.py
@@ -1,0 +1,72 @@
+import os
+import random
+import string
+
+from shakedown import *
+
+
+def test_copy_file():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    assert copy_file(master_ip(), '/tmp/' + filename)
+    assert run_command(master_ip(), 'cat ' + filename)
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_to_master():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    assert copy_file_to_master('/tmp/' + filename)
+    assert run_command(master_ip(), 'cat ' + filename)
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_to_agent():
+    filename = ''.join(random.choice(string.ascii_uppercase) for i in range(12))
+    f = open('/tmp/' + filename, 'w')
+    f.write('Hello world!')
+    f.close()
+
+    if not package_installed('jenkins'):
+        install_package_and_wait('jenkins')
+
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
+    for host in service_ips:
+        assert copy_file_to_agent(host, '/tmp/' + filename)
+        assert run_command_on_agent(host, 'cat ' + filename)
+
+    if package_installed('jenkins'):
+        uninstall_package_and_wait('jenkins')
+
+    os.remove('/tmp/' + filename)
+
+
+def test_copy_file_from_master():
+    assert copy_file_from_master('/etc/motd')
+
+    f = open('motd', 'r')
+    print(f.read())
+    f.close()
+
+
+def test_copy_file_from_agent():
+    if not package_installed('jenkins'):
+        install_package_and_wait('jenkins')
+
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
+    for host in service_ips:
+        assert copy_file_from_agent(host, '/etc/motd')
+
+    f = open('motd', 'r')
+    print(f.read())
+    f.close()


### PR DESCRIPTION
Five exciting new API methods for the low, low cost of only ONE merge:
- `shakedown.dcos.file.copy_file()`
- `shakedown.dcos.file.copy_file_to_master()`
- `shakedown.dcos.file.copy_file_to_agent()`
- `shakedown.dcos.file.copy_file_from_master()`
- `shakedown.dcos.file.copy_file_from_agent()`

In addition, SSH/SCP transport operations have been moved to a helpers
file/library, `shakedown/dcos/helpers.py`.
