### PR TITLE
Split using `shlex.split()` to preserve quotes

### DIFF
--- a/shakedown/dcos/command.py
+++ b/shakedown/dcos/command.py
@@ -1,4 +1,5 @@
 import select
+import shlex
 import subprocess
 
 from shakedown.dcos.helpers import *
@@ -90,7 +91,7 @@ def run_dcos_command(command):
         :rtype: tuple
     """
 
-    call = command.split()
+    call = shlex.split(command)
     call.insert(0, 'dcos')
 
     print("\n{}{}\n".format(shakedown.cli.helpers.fchr('>>'), ' '.join(call)))


### PR DESCRIPTION
`shlex` is part of Python's standard library.
