### PR TITLE
Fall back to keys from running SSH agent if no key file is supplied

### DIFF
--- a/shakedown/dcos/helpers.py
+++ b/shakedown/dcos/helpers.py
@@ -52,7 +52,20 @@ def start_transport(transport, username, key):
     """
 
     transport.start_client()
-    transport.auth_publickey(username, key)
+
+    if key:
+        transport.auth_publickey(username, key)
+        return transport
+
+    agent = paramiko.agent.Agent()
+    for key in agent.get_keys():
+        try:
+            transport.auth_publickey(username, key)
+            break
+        except paramiko.AuthenticationException as e:
+            pass
+    else:
+        raise ValueError('No valid key supplied')
 
     return transport
 


### PR DESCRIPTION
Some CI environments manage SSH keys via `ssh-agent`, leaving no private key file available in the workspace. Currently, `shakedown` only supports supplying a private key via a file, which makes running SSH commands against DC/OS nodes impossible in those environments. This change allows `shakedown` to fall back to keys managed by a running SSH agent, failing to authenticate only after all of those have been attempted.