### PR TITLE
Make Shakedown CI Green Again!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='shakedown',
       zip_safe=False,
       install_requires=[
           'click',
-          'dcoscli==0.4.4',
+          'dcoscli==0.4.10',
           'paramiko',
           'pytest',
           'scp'

--- a/shakedown/__init__.py
+++ b/shakedown/__init__.py
@@ -9,4 +9,4 @@ from shakedown.dcos.task import *
 from shakedown.dcos.zookeeper import *
 from shakedown.dcos.agent import *
 
-VERSION='1.0.0'
+VERSION='1.0.1'

--- a/shakedown/dcos/__init__.py
+++ b/shakedown/dcos/__init__.py
@@ -8,7 +8,7 @@ def dcos_acs_token():
     """Return the DCOS ACS token as configured in the DCOS library.
     :return: DCOS ACS token as a string
     """
-    return dcos.util.get_config().get('core.dcos_acs_token')
+    return dcos.config.get_config().get('core.dcos_acs_token')
 
 
 def dcos_url():
@@ -17,7 +17,7 @@ def dcos_url():
     command line.
     :return: DCOS cluster URL as a string
     """
-    return dcos.util.get_config().get('core.dcos_url')
+    return dcos.config.get_config().get('core.dcos_url')
 
 
 def dcos_service_url(service):

--- a/shakedown/dcos/command.py
+++ b/shakedown/dcos/command.py
@@ -49,8 +49,8 @@ def run_command(
                 recv = str(channel.recv(1024), "utf-8")
                 print(recv, end='', flush=True)
 
-        channel.close()
-        transport.close()
+        try_close(channel)
+        try_close(transport)
 
         return True
     else:

--- a/shakedown/dcos/file.py
+++ b/shakedown/dcos/file.py
@@ -54,8 +54,8 @@ def copy_file(
 
         print(str(os.path.getsize(file_path)) + ' bytes copied in ' + str(round(time.time() - start, 2))  + ' seconds.')
 
-        channel.close()
-        transport.close()
+        try_close(channel)
+        try_close(transport)
 
         return True
     else:

--- a/shakedown/dcos/helpers.py
+++ b/shakedown/dcos/helpers.py
@@ -70,6 +70,16 @@ def start_transport(transport, username, key):
     return transport
 
 
+# SSH connection will be auto-terminated at the conclusion of this operation, causing
+# a race condition; the try/except block attempts to close the channel and/or transport
+# but does not issue a failure if it has already been closed.
+def try_close(obj):
+    try:
+        obj.close()
+    except:
+        pass
+
+
 def validate_key(key_path):
     """ Validate a key
 

--- a/shakedown/dcos/package.py
+++ b/shakedown/dcos/package.py
@@ -2,7 +2,7 @@ import json
 import time
 
 from dcos import (cosmospackage, subcommand)
-from dcoscli.package.main import _get_cosmos_url
+from dcoscli.package.main import get_cosmos_url
 
 import shakedown
 
@@ -32,7 +32,7 @@ def _get_cosmos():
         :rtype: cosmospackage.Cosmos
     """
 
-    return cosmospackage.Cosmos(_get_cosmos_url())
+    return cosmospackage.Cosmos(get_cosmos_url())
 
 
 def install_package(
@@ -67,9 +67,9 @@ def install_package(
     pkg = cosmos.get_package_version(package_name, package_version)
 
     # Install subcommands (if defined)
-    if pkg.has_command_definition():
+    if pkg.has_cli_definition():
         print("\n{}installing CLI commands for package '{}'\n".format(shakedown.cli.helpers.fchr('>>'), package_name))
-        subcommand.install(pkg, pkg.options(options))
+        subcommand.install(pkg)
 
     print("\n{}installing package '{}'\n".format(shakedown.cli.helpers.fchr('>>'), package_name))
 
@@ -169,7 +169,7 @@ def uninstall_package(
     pkg = cosmos.get_package_version(package_name, None)
 
     # Uninstall subcommands (if defined)
-    if pkg.has_command_definition():
+    if pkg.has_cli_definition():
         print("\n{}uninstalling CLI commands for package '{}'\n".format(shakedown.cli.helpers.fchr('>>'), package_name))
         subcommand.uninstall(package_name)
 

--- a/shakedown/dcos/service.py
+++ b/shakedown/dcos/service.py
@@ -155,11 +155,8 @@ def get_service_ips(
     for task in service_tasks:
         if task_name is not None:
             if task['name'] == task_name:
-                if task['statuses'][0]['container_status']['network_infos'][0]['ip_address']:
-                    ips.add(task['statuses'][0]['container_status']['network_infos'][0]['ip_address'])
-        else:
-            if task['statuses'][0]['container_status']['network_infos'][0]['ip_address']:
-                ips.add(task['statuses'][0]['container_status']['network_infos'][0]['ip_address'])
+                for ip in task['statuses'][0]['container_status']['network_infos'][0]['ip_addresses']:
+                    ips.add(ip['ip_address'])
 
     return ips
 

--- a/tests/acceptance/test_00_setup.py
+++ b/tests/acceptance/test_00_setup.py
@@ -1,0 +1,6 @@
+from shakedown import *
+
+
+def test_install_package_jenkins():
+    if not package_installed('jenkins'):
+        install_package_and_wait('jenkins')

--- a/tests/acceptance/test_dcos_command.py
+++ b/tests/acceptance/test_dcos_command.py
@@ -10,16 +10,10 @@ def test_run_command_on_master():
     assert run_command_on_master('uname -a')
 
 def test_run_command_on_agent():
-    if not package_installed('jenkins'):
-        install_package_and_wait('jenkins')
-
     # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
     service_ips = get_service_ips('marathon', 'jenkins')
     for host in service_ips:
         assert run_command_on_agent(host, 'ps -eaf | grep -i docker | grep -i jenkins')
-
-    if package_installed('jenkins'):
-        uninstall_package_and_wait('jenkins')
 
 def test_run_dcos_command():
     result, error = run_dcos_command('package search jenkins --json')

--- a/tests/acceptance/test_dcos_file.py
+++ b/tests/acceptance/test_dcos_file.py
@@ -35,17 +35,11 @@ def test_copy_file_to_agent():
     f.write('Hello world!')
     f.close()
 
-    if not package_installed('jenkins'):
-        install_package_and_wait('jenkins')
-
     # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
     service_ips = get_service_ips('marathon', 'jenkins')
     for host in service_ips:
         assert copy_file_to_agent(host, '/tmp/' + filename)
         assert run_command_on_agent(host, 'cat ' + filename)
-
-    if package_installed('jenkins'):
-        uninstall_package_and_wait('jenkins')
 
     os.remove('/tmp/' + filename)
 
@@ -61,9 +55,6 @@ def test_copy_file_from_master():
 
 
 def test_copy_file_from_agent():
-    if not package_installed('jenkins'):
-        install_package_and_wait('jenkins')
-
     # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
     service_ips = get_service_ips('marathon', 'jenkins')
     for host in service_ips:
@@ -72,8 +63,5 @@ def test_copy_file_from_agent():
     f = open('motd', 'r')
     print(f.read())
     f.close()
-
-    if package_installed('jenkins'):
-        uninstall_package_and_wait('jenkins')
 
     os.remove('motd')

--- a/tests/acceptance/test_dcos_package.py
+++ b/tests/acceptance/test_dcos_package.py
@@ -4,14 +4,14 @@ from shakedown import *
 
 
 def test_install_package_and_wait():
-    assert not package_installed('jenkins')
-    install_package_and_wait('jenkins')
-    assert package_installed('jenkins')
+    assert not package_installed('marathon-lb')
+    install_package_and_wait('marathon-lb')
+    assert package_installed('marathon-lb')
 
 def test_uninstall_package_and_wait():
-    assert package_installed('jenkins')
-    uninstall_package_and_wait('jenkins')
-    assert package_installed('jenkins') == False
+    assert package_installed('marathon-lb')
+    uninstall_package_and_wait('marathon-lb')
+    assert package_installed('marathon-lb') == False
 
 def test_install_package_with_subcommand():
     install_package_and_wait('spark')

--- a/tests/acceptance/test_dcos_service.py
+++ b/tests/acceptance/test_dcos_service.py
@@ -4,49 +4,27 @@ from shakedown import *
 
 
 def test_get_service_framework_id():
-    assert get_service_framework_id('jenkins') is None
-
-    install_package_and_wait('jenkins')
     framework_id = get_service_framework_id('jenkins')
     print('framework_id: ' + framework_id)
     assert framework_id is not None
 
-    uninstall_package_and_wait('jenkins')
-    assert get_service_framework_id('jenkins') is None
-
 
 def test_get_service_tasks():
-    install_package_and_wait('hdfs')
     service_tasks = get_service_tasks('marathon')
     assert service_tasks is not None
 
-    uninstall_package_and_wait('hdfs')
-
 
 def test_get_service_task():
-    install_package_and_wait('jenkins')
     service_task = get_service_task('marathon', 'jenkins')
     assert service_task is not None
 
-    uninstall_package_and_wait('jenkins')
-
 
 def test_get_service_ips():
-    install_package_and_wait('chronos')
-
-    # Get all IPs associated with the 'chronos' task running in the 'marathon' service
-    service_ips = get_service_ips('marathon', 'chronos')
+    # Get all IPs associated with the 'jenkins' task running in the 'marathon' service
+    service_ips = get_service_ips('marathon', 'jenkins')
     assert service_ips is not None
     print('service_ips: ' + str(service_ips))
 
-    uninstall_package_and_wait('chronos')
-
 
 def test_service_healthy():
-    assert not service_healthy('jenkins')
-    install_package_and_wait('jenkins')
-
-    time.sleep(60)
     assert service_healthy('jenkins')
-
-    uninstall_package_and_wait('jenkins')

--- a/tests/acceptance/test_dcos_task.py
+++ b/tests/acceptance/test_dcos_task.py
@@ -2,12 +2,8 @@ from shakedown import *
 
 
 def test_get_active_tasks():
-    install_package_and_wait('jenkins')
-
     task_names = []
     for task in get_active_tasks():
         task_names.append(task['name'])
 
     assert 'jenkins' in task_names
-
-    uninstall_package_and_wait('jenkins')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,4 +13,4 @@ def test_cli_version():
     result = runner.invoke(cli.main.cli, ['--version'])
     assert result.exit_code == 0
     assert result.output == "shakedown, version " + shakedown.VERSION + "\n"
-
+    print(result.output)


### PR DESCRIPTION
- bump `shakedown` to `1.0.1`
- update `dcos-cli` to `0.4.10`
- allow for paramiko (SSH) connection-closing race condition bug with `try_close()`
- update acceptance tests
  - don't continually install and uninstall Jenkins; just once at beginning of test run
  - package install/uninstall tests uses `marathon-lb` now since Jenkins will already be installed in test run setup