### PR TITLE
Return all task ips when task_name is None

### DIFF
--- a/shakedown/dcos/service.py
+++ b/shakedown/dcos/service.py
@@ -153,10 +153,9 @@ def get_service_ips(
     ips = set([])
 
     for task in service_tasks:
-        if task_name is not None:
-            if task['name'] == task_name:
-                for ip in task['statuses'][0]['container_status']['network_infos'][0]['ip_addresses']:
-                    ips.add(ip['ip_address'])
+        if task_name is None or task['name'] == task_name:
+            for ip in task['statuses'][0]['container_status']['network_infos'][0]['ip_addresses']:
+                ips.add(ip['ip_address'])
 
     return ips
 


### PR DESCRIPTION
Previously, `get_service_ips` returned all task IPs when the `task_name` argument was `None`, only filtering on task name when one was provided. Now it returns only the empty set in that case. I believe the former behavior is still intended (otherwise this function should be named `get_task_ip`), so this PR restores it.