### PR TITLE
Remove 'key not found' error

### DIFF
--- a/shakedown/dcos/helpers.py
+++ b/shakedown/dcos/helpers.py
@@ -93,7 +93,6 @@ def validate_key(key_path):
     key_path = os.path.expanduser(key_path)
 
     if not os.path.isfile(key_path):
-        print('error: key not found: ' + key_path)
         return False
 
     return paramiko.RSAKey.from_private_key_file(key_path)


### PR DESCRIPTION
By default, shakedown/paramiko will look for a valid key (default: `~/.ssh/id_rsa`), then fall back to those loaded in `ssh-agent`.  Previous to this patch, an error would be continually displayed if `~/.ssh/id_rsa` could not be found.  With this removal, the entire keychain will be examined and an error only displayed if no valid key is available for use.