### PR TITLE
(maint) Fix `dcos-shakedown` command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='dcos-shakedown',
       entry_points="""
       [console_scripts]
       shakedown=shakedown.cli.main:cli
-      dcos-shakedown=shakedown.cli:cli
+      dcos-shakedown=shakedown.cli.main:cli
       """
       )


### PR DESCRIPTION
Without this fix:

```
$ dcos-shakedown --version
Traceback (most recent call last):
      File
      "/Users/scott/Documents/Code/virtualenvs/shakedown/bin/dcos-shakedown",
      line 7, in <module>
          from shakedown.cli import cli
      ImportError: cannot import name 'cli'
```