### PR TITLE
Initial support for OAuth token instead of user/pass

### DIFF
--- a/shakedown/dcos/__init__.py
+++ b/shakedown/dcos/__init__.py
@@ -82,6 +82,24 @@ def authenticate(username, password):
         return None
 
 
+def authenticate_oauth(oauth_token):
+    """Authenticate by checking for a valid OAuth token.
+    return: ACS token
+    """
+    url = _gen_url('acs/api/v1/auth/login')
+
+    creds = {
+        'token': oauth_token
+    }
+
+    response = dcos.http.request('post', url, json=creds)
+
+    if response.status_code == 200:
+        return response.json()['token']
+    else:
+        return None
+
+
 def _gen_url(url_path):
     """Return an absolute URL by combining DC/OS URL and url_path.
 

--- a/tests/acceptance/test_dcos_service.py
+++ b/tests/acceptance/test_dcos_service.py
@@ -4,7 +4,7 @@ from shakedown import *
 
 
 def test_get_service_framework_id():
-    framework_id = get_service_framework_id('jenkins')
+    framework_id = get_service_framework_id('marathon')
     print('framework_id: ' + framework_id)
     assert framework_id is not None
 


### PR DESCRIPTION
By specifying `oauth_token` in a `.shakedown` file, an existing OAuth token can be validated rather than a username/password pair.