### PR TITLE
(maint) Fix test specification

### DIFF
--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -303,7 +303,11 @@ def cli(**args):
             opts.append(opt)
 
     if args['tests']:
-        opts.append(' '.join(args['tests']))
+        tests_to_run = []
+        for test in args['tests']:
+            tests_to_run.extend(test.split())
+        for test in tests_to_run:
+            opts.append(test)
 
     exitstatus = imported['pytest'].main(opts, plugins=[shakedown()])
 


### PR DESCRIPTION
Allow single tests to be run (`test_file.py::test_name`) in combination
with multiple specified test files (`test_file.py::test_name test_file_2.py`)