### PR TITLE
Authentication cmdline opts

### DIFF
--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -9,7 +9,7 @@ from shakedown.cli.helpers import *
 
 @click.command('shakedown')
 @click.argument('tests', nargs=-1)
-@click.option('-u', '--dcos-url', help='URL to a running DCOS cluster.')
+@click.option('-u', '--dcos-url', help='URL to a running DC/OS cluster.')
 @click.option('-f', '--fail', type=click.Choice(['fast', 'never']), help='Sepcify whether to continue testing when encountering failures. (default: fast)')
 @click.option('-i', '--ssh-key-file', type=click.Path(), help='Path to the SSH keyfile to use for authentication.')
 @click.option('-q', '--quiet', is_flag=True, help='Suppress all superfluous output.')

--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -17,6 +17,9 @@ from shakedown.cli.helpers import *
 @click.option('-o', '--stdout', type=click.Choice(['pass', 'fail', 'skip', 'all', 'none']), help='Print the standard output of tests with the specified result. (default: fail)')
 @click.option('-s', '--stdout-inline', is_flag=True, help='Display output inline rather than after test phase completion.')
 @click.option('-p', '--pytest-option', multiple=True, help='Options flags to pass to pytest.')
+@click.option('-t', '--oauth-token', help='OAuth token to use for DC/OS authentication.')
+@click.option('-n', '--username', help='Username to use for DC/OS authentication.')
+@click.option('-w', '--password', hide_input=True, help='Password to use for DC/OS authentication.')
 @click.option('--no-banner', is_flag=True, help='Suppress the product banner.')
 @click.version_option(version=shakedown.VERSION)
 

--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -95,7 +95,7 @@ def cli(**args):
             authenticated = True
         except imported['dcos'].errors.DCOSException:
             click.secho("error: authentication failed.", fg='red', bold=True)
-    if not authenticated and set(['oauth_token']).issubset(args):
+    if not authenticated and args['oauth_token']:
        try:
             echo('Validating OAuth token...', d='step-min', n=False)
             token = shakedown.authenticate_oauth(args['oauth_token'])
@@ -107,7 +107,7 @@ def cli(**args):
             echo('ok')
        except:
             click.secho("error: authentication failed.", fg='red', bold=True)
-    if not authenticated and set(['username', 'password']).issubset(args):
+    if not authenticated and args['username'] and args['password']:
         try:
             echo('Validating username and password...', d='step-min', n=False)
             token = shakedown.authenticate(args['username'], args['password'])

--- a/shakedown/dcos/__init__.py
+++ b/shakedown/dcos/__init__.py
@@ -5,26 +5,26 @@ import shakedown
 
 
 def dcos_acs_token():
-    """Return the DCOS ACS token as configured in the DCOS library.
-    :return: DCOS ACS token as a string
+    """Return the DC/OS ACS token as configured in the DC/OS library.
+    :return: DC/OS ACS token as a string
     """
     return dcos.config.get_config().get('core.dcos_acs_token')
 
 
 def dcos_url():
-    """Return the DCOS URL as configured in the DCOS library. This is
+    """Return the DC/OS URL as configured in the DC/OS library. This is
     equivalent to the value of '--dcos_url' passed into Shakedown on the
     command line.
-    :return: DCOS cluster URL as a string
+    :return: DC/OS cluster URL as a string
     """
     return dcos.config.get_config().get('core.dcos_url')
 
 
 def dcos_service_url(service):
-    """Return the URL of a service running on DCOS, based on the value of
+    """Return the URL of a service running on DC/OS, based on the value of
     shakedown.dcos.dcos_url() and the service name.
-    :param service: the name of a registered DCOS service, as a string
-    :return: the full DCOS service URL, as a string
+    :param service: the name of a registered DC/OS service, as a string
+    :return: the full DC/OS service URL, as a string
     """
     return _gen_url("/service/{}".format(service))
 
@@ -57,8 +57,8 @@ def dcos_version():
 
 
 def master_ip():
-    """Returns the public IP address of the DCOS master.
-    return: DCOS IP address as a string
+    """Returns the public IP address of the DC/OS master.
+    return: DC/OS IP address as a string
     """
     return dcos.mesos.DCOSClient().metadata().get('PUBLIC_IPV4')
 

--- a/shakedown/dcos/command.py
+++ b/shakedown/dcos/command.py
@@ -82,7 +82,7 @@ def run_command_on_agent(
 
 
 def run_dcos_command(command):
-    """ Run a command via DCOS CLI
+    """ Run a command via DC/OS CLI
 
         :param command: the command to execute
         :type command: str

--- a/shakedown/dcos/package.py
+++ b/shakedown/dcos/package.py
@@ -43,7 +43,7 @@ def install_package(
         wait_for_completion=False,
         timeout_sec=600
 ):
-    """ Install a package via the DCOS library
+    """ Install a package via the DC/OS library
 
         :param package_name: name of the package
         :type package_name: str
@@ -110,7 +110,7 @@ def install_package_and_wait(
         wait_for_completion=True,
         timeout_sec=600
 ):
-    """ Install a package via the DCOS library and wait for completion
+    """ Install a package via the DC/OS library and wait for completion
     """
 
     return install_package(
@@ -146,7 +146,7 @@ def uninstall_package(
         wait_for_completion=False,
         timeout_sec=600
 ):
-    """ Uninstall a package using the DCOS library.
+    """ Uninstall a package using the DC/OS library.
 
         :param package_name: name of the package
         :type package_name: str
@@ -199,7 +199,7 @@ def uninstall_package_and_wait(
         wait_for_completion=True,
         timeout_sec=600
 ):
-    """ Install a package via the DCOS library and wait for completion
+    """ Install a package via the DC/OS library and wait for completion
     """
 
     return uninstall_package(

--- a/tests/acceptance/test_dcos_zookeeper.py
+++ b/tests/acceptance/test_dcos_zookeeper.py
@@ -13,7 +13,7 @@ def test_delete_zk_node():
             break
         time.sleep(1)
 
-    assert found, 'Service did not register with DCOS'
+    assert found, 'Service did not register with DC/OS'
 
     task_names = []
     for task in get_active_tasks():


### PR DESCRIPTION
Add the following command-line arguments:

- `-t`, `--oauth-token`, OAuth token to use for DC/OS authentication.
- `-n`, `--username`, Username to use for DC/OS authentication.
- `-w`, `--password`, Password to use for DC/OS authentication.

This PR also includes a fixup to only attempt an authentication vector if the related arguments are defined, and updated documentation from "DCOS" to "DC/OS".