### PR TITLE
`test_install_package_with_json_options` set to `xfail`

### DIFF
--- a/tests/acceptance/test_dcos_package.py
+++ b/tests/acceptance/test_dcos_package.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from shakedown import *
 
@@ -21,7 +22,7 @@ def task_cpu_predicate(service, task):
 
         return (response is not None) and ('resources' in response) and ('cpus' in response['resources'])
 
-
+@pytest.mark.xfail(reason='Flaky test')
 def test_install_package_with_json_options():
     install_package_and_wait('chronos', None, 'big-chronos', None, {"chronos": {"cpus": 2}})
     wait_for(lambda: task_cpu_predicate('marathon', 'big-chronos'))


### PR DESCRIPTION
This test fails often for unknown reasons; setting it to `xfail` until
this can be properly resolved.