### PR TITLE
Upstream fixes/functionality from dcos-commons

### DIFF
--- a/shakedown/dcos/marathon.py
+++ b/shakedown/dcos/marathon.py
@@ -11,20 +11,20 @@ def deployment_wait(timeout=120, app_id=None):
               timeout)
 
 
-def delete_app(app_id, force=False):
+def delete_app(app_id, force=True):
     marathon.create_client().remove_app(app_id, force=force)
 
 
-def delete_app_wait(app_id, force=False):
+def delete_app_wait(app_id, force=True):
     delete_app(app_id, force)
     deployment_wait(app_id=app_id)
 
 
-def delete_all_apps(force=False):
+def delete_all_apps(force=True):
     marathon.create_client().remove_group("/", force=force)
 
 
-def delete_all_apps_wait(force=False):
+def delete_all_apps_wait(force=True):
     delete_all_apps(force=force)
     deployment_wait()
 

--- a/shakedown/dcos/marathon.py
+++ b/shakedown/dcos/marathon.py
@@ -3,8 +3,7 @@ from shakedown.dcos.spinner import *
 
 
 def deployment_predicate(app_id=None):
-    client = marathon.create_client()
-    return len(client.get_deployments()) == 0
+    return len(marathon.create_client().get_deployments(app_id)) == 0
 
 
 def deployment_wait(timeout=120, app_id=None):
@@ -12,20 +11,26 @@ def deployment_wait(timeout=120, app_id=None):
               timeout)
 
 
-def delete_all_apps():
-    client = marathon.create_client()
-    client.remove_group("/")
+def delete_app(app_id, force=False):
+    marathon.create_client().remove_app(app_id, force=force)
 
 
-def delete_all_apps_wait():
-    delete_all_apps()
+def delete_app_wait(app_id, force=False):
+    delete_app(app_id, force)
+    deployment_wait(app_id=app_id)
+
+
+def delete_all_apps(force=False):
+    marathon.create_client().remove_group("/", force=force)
+
+
+def delete_all_apps_wait(force=False):
+    delete_all_apps(force=force)
     deployment_wait()
 
 
 def is_app_healthy(app_id):
-    client = marathon.create_client()
-    app = client.get_app(app_id)
-
+    app = marathon.create_client().get_app(app_id)
     if app["healthChecks"]:
         return app["tasksHealthy"] == app["instances"]
     else:

--- a/shakedown/dcos/package.py
+++ b/shakedown/dcos/package.py
@@ -258,64 +258,6 @@ def uninstall_package_and_wait(
     )
 
 
-def uninstall_package_and_data(
-        package_name,
-        service_name=None,
-        role=None,
-        principal=None,
-        zk_node=None,
-        timeout_sec=600):
-    """ Uninstall a package via the DC/OS library, wait for completion, and delete any persistent data
-
-        :param package_name: name of the package
-        :type package_name: str
-        :param service_name: unique service name for the package
-        :type service_name: str
-        :param role: role to use when deleting data, or <service_name>-role if unset
-        :type role: str, or None
-        :param principal: principal to use when deleting data, or <service_name>-principal if unset
-        :type principal: str, or None
-        :param zk_node: zk node to delete, or dcos-service-<service_name> if unset
-        :type zk_node: str, or None
-        :param wait_for_completion: whether or not to wait for task completion before returning
-        :type wait_for_completion: bool
-        :param timeout_sec: number of seconds to wait for task completion
-        :type timeout_sec: int
-    """
-    start = time.time()
-
-    if service_name is None:
-        pkg = _get_package_manager().get_package_version(package_name, None)
-        service_name = _get_service_name(package_name, pkg)
-    print('\n{}uninstalling/deleting {}'.format(shakedown.cli.helpers.fchr('>>'), service_name))
-
-    try:
-        uninstall_package_and_wait(package_name, service_name=service_name, timeout_sec=timeout_sec)
-    except (errors.DCOSException, ValueError) as e:
-        print('Got exception when uninstalling package, ' +
-              'continuing with janitor anyway: {}'.format(e))
-
-    data_start = time.time()
-
-    if (not role or not principal or not zk_node) and service_name is None:
-        raise DCOSException('service_name must be provided when data params are missing AND the package isn\'t installed')
-    if not role:
-        role = '{}-role'.format(service_name)
-    if not principal:
-        principal = '{}-principal'.format(service_name)
-    if not zk_node:
-        zk_node = 'dcos-service-{}'.format(service_name)
-    delete_persistent_data(role, principal, zk_node)
-
-    finish = time.time()
-
-    print('\n{}uninstall/delete done after pkg({}) + data({}) = total({})\n'.format(
-        shakedown.cli.helpers.fchr('>>'),
-        pretty_duration(data_start - start),
-        pretty_duration(finish - data_start),
-        pretty_duration(finish - start)))
-
-
 def get_package_repos():
     """ Return a list of configured package repositories
     """

--- a/shakedown/dcos/service.py
+++ b/shakedown/dcos/service.py
@@ -309,6 +309,20 @@ def wait_for_service_endpoint_removal(service_name, timeout_sec=120):
 
 
 def task_states_predicate(service_name, expected_task_count, expected_task_states):
+    """ Returns whether the provided service_names's tasks have expected_task_count tasks
+        in any of expected_task_states. For example, if service 'foo' has 5 tasks which are
+        TASK_STAGING or TASK_RUNNING.
+
+        :param service_name: the service name
+        :type service_name: str
+        :param expected_task_count: the number of tasks which should have an expected state
+        :type expected_task_count: int
+        :param expected_task_states: the list states to search for among the service's tasks
+        :type expected_task_states: [str]
+
+        :return: True if expected_task_count tasks have any of expected_task_states, False otherwise
+        :rtype: bool
+    """
     try:
         tasks = get_service_tasks(service_name)
     except DCOSHTTPException:
@@ -345,6 +359,9 @@ def wait_for_service_tasks_state(
         :type expected_task_states: [str]
         :param timeout_sec: duration to wait
         :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
     """
     return time_wait(
         lambda: task_states_predicate(service_name, expected_task_count, expected_task_states),
@@ -364,6 +381,9 @@ def wait_for_service_tasks_running(
         :type expected_task_count: int
         :param timeout_sec: duration to wait
         :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
     """
     return wait_for_service_tasks_state(service_name, expected_task_count, ['TASK_RUNNING'], timeout_sec)
 
@@ -381,6 +401,9 @@ def tasks_all_replaced_predicate(
         :type old_task_ids: [str]
         :param task_predicate: filter to use when searching for tasks
         :type task_predicate: func
+
+        :return: True if none of old_task_ids are still present in the service
+        :rtype: bool
     """
     try:
         task_ids = get_service_task_ids(service_name, task_predicate)
@@ -411,6 +434,9 @@ def tasks_missing_predicate(
         :type old_task_ids: [str]
         :param task_predicate: filter to use when searching for tasks
         :type task_predicate: func
+
+        :return: True if any of old_task_ids are no longer present in the service
+        :rtype: bool
     """
     try:
         task_ids = get_service_task_ids(service_name, task_predicate)
@@ -442,6 +468,9 @@ def wait_for_service_tasks_all_changed(
         :type task_predicate: func
         :param timeout_sec: duration to wait
         :type timeout_sec: int
+
+        :return: the duration waited in seconds
+        :rtype: int
     """
     return time_wait(
         lambda: tasks_all_replaced_predicate(service_name, old_task_ids, task_predicate),
@@ -464,6 +493,9 @@ def wait_for_service_tasks_all_unchanged(
         :type task_predicate: func
         :param timeout_sec: duration to wait until assuming tasks are unchanged
         :type timeout_sec: int
+
+        :return: the duration waited in seconds (the timeout value)
+        :rtype: int
     """
     try:
         time_wait(

--- a/shakedown/dcos/service.py
+++ b/shakedown/dcos/service.py
@@ -252,28 +252,6 @@ def wait_for_mesos_task_removal(task_name, timeout_sec=120):
     return time_wait(lambda: mesos_task_not_present_predicate(task_name), timeout_seconds=timeout_sec)
 
 
-def delete_persistent_data(role, principal, zk_node):
-    """ Deletes any persistent data associated with the specified role, principal, and zk node.
-
-        :param role: the mesos role to delete, or None to omit this
-        :type role: str
-        :param principal: the mesos principal for the data to delete, or None to omit this
-        :type principal: str
-        :param zk_node: the zookeeper node to be deleted, or None to skip this deletion
-        :type zk_node: str
-    """
-    janitor_cmd = ['docker run mesosphere/janitor /janitor.py']
-    if role:
-        janitor_cmd.append('-r {}'.format(role))
-    if principal:
-        janitor_cmd.append('-p {}'.format(principal))
-    if zk_node:
-        janitor_cmd.append('-z {}'.format(zk_node))
-    janitor_cmd.append('--auth_token={}'.format(
-        run_dcos_command('config show core.dcos_acs_token', print_output=False)[0].strip()))
-    run_command_on_master(' '.join(janitor_cmd))
-
-
 def service_available_predicate(service_name):
     url = dcos_service_url(service_name)
     try:

--- a/shakedown/dcos/spinner.py
+++ b/shakedown/dcos/spinner.py
@@ -27,7 +27,7 @@ def wait_for(predicate, timeout_seconds=120, sleep_seconds=1, ignore_exceptions=
             if (not inverse_predicate and result) or (inverse_predicate and not result):
                 return result
             if timeout.is_expired():
-                raise TimeoutExpired(timeout_seconds, str(predicate))
+                raise TimeoutExpired(timeout_seconds, str(predicate.__name__))
         if noisy:
             print('{}[{}/{}] spinning...'.format(
                 shakedown.cli.helpers.fchr('>>'),

--- a/shakedown/dcos/task.py
+++ b/shakedown/dcos/task.py
@@ -10,7 +10,7 @@ import time
 
 
 def get_tasks(task_id='', completed=True):
-    """ Get a list of tasks, optionally filtered by task name.
+    """ Get a list of tasks, optionally filtered by task id.
 
         :param task_id: task ID
         :type task_id: str
@@ -108,7 +108,7 @@ def wait_for_task(service, task, timeout_sec=120):
 
 
 def wait_for_task_property(service, task, prop, timeout_sec=120):
-    """Waits for a task which was launched to be launched"""
+    """Waits for a task to have the specified property"""
     return time_wait(lambda: task_property_present_predicate(service, task, prop), timeout_seconds=timeout_sec)
 
 


### PR DESCRIPTION
- command: Allow disabling output and/or raising on error, when `dcos` is invoked
- marathon: fix unused app_id when checking deployment
- marathon: add `delete_app`/`delete_app_wait` for a specific app
- package: (install) support waiting for service tasks to start RUNNING, add logging
- package: (uninstall) add docs, support deleting persistent volumes after uninstall
- package: (repo) support waiting for add/remove repo to actually complete: check for a changed package version
- service: doc/indent corrections
- service: add helper for retrieving task ids
- service: add function for deleting mesos' persistent volumes (invoked by package)
- service: support waiting for task rollout to complete (wait for task ids to change)
- service: support verifying that tasks are not changed (ensure task ids dont change for some interval)
- spinner: while a spinner is polling, print the spin time and any ignored exceptions by default
- spinner: don't drop the original stack when rethrowing exceptions
- spinner: return the result of the spin at the end of `wait_for`, allowing passthrough of the predicate return value
- task: doc corrections
