### PR TITLE
turn off noisy option in wait_for

### DIFF
--- a/shakedown/dcos/spinner.py
+++ b/shakedown/dcos/spinner.py
@@ -4,7 +4,13 @@ import traceback
 import shakedown
 
 
-def wait_for(predicate, timeout_seconds=120, sleep_seconds=1, ignore_exceptions=True, inverse_predicate=False, noisy=True):
+def wait_for(
+        predicate,
+        timeout_seconds=120,
+        sleep_seconds=1,
+        ignore_exceptions=True,
+        inverse_predicate=False,
+        noisy=False):
     """ waits or spins for a predicate, returning the result.
         Predicate is a function that returns a truthy or falsy value.
         An exception in the function will be returned.


### PR DESCRIPTION
We shouldn't be printing stack traces unless there's an actual error.  cc @nickbp 