### PR TITLE
Fix dcos_agents_state() example usage

### DIFF
--- a/API.md
+++ b/API.md
@@ -259,7 +259,7 @@ None.
 
 ```python
 # Print state information of DC/OS slaves.
-state_json = json.loads(dcos_agents_state())
+state_json = dcos_agents_state()
 print(state_json['slaves'])
 ```
 


### PR DESCRIPTION
Removed unneeded JSON parsing from dcos_agents_state() example usage. Currently you get `TypeError: the JSON object must be str, not 'dict'` because it's already a json hierarchy.