### PR TITLE
Provide spinner for sometimes-exception methods.

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,6 +83,7 @@
     * Spinner
       * [wait_for()](#wait_for)
       * [time_wait()](#time_wait)
+      * [wait_while_exceptions()](#wait_while_exceptions)
       * [elapse_time()](#elapse_time)
     * Tasks
       * [get_task()](#get_task)
@@ -1459,6 +1460,37 @@ def service_available_predicate(service_name):
   ...
 
 time_wait(lambda: service_available_predicate(service_name), timeout_seconds=timeout_sec)
+
+```
+
+### wait_while_exceptions()
+
+Waits for a function to return without exception or time out.  Returns the return value of the function.
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+**predicate** | the predicate function| fn
+timeout_seconds | how long in seconds to wait before timing out | int | `120`
+sleep_seconds | time to sleep between multiple calls to predicate | int | `1`
+noisy | boolean to increase debug output | bool | True
+
+
+##### *example usage*
+
+```python
+# simple predicate
+def deployment_predicate(client=None):
+  ...
+
+wait_while_exceptions(deployment_predicate, timeout)
+
+# predicate with a parameter
+def service_available_predicate(service_name):
+  ...
+
+wait_while_exceptions(lambda: service_available_predicate(service_name), timeout_seconds=timeout_sec)
 
 ```
 


### PR DESCRIPTION
We (in a dcos-commons test) currently are spinning on `wait_for(docs.http.request, ...)`, but this is wrong because if we get an empty response json document (`""` or `"{}"`), it will wait forever since those values are false.  This is causing a test failure currently.

The most common success/fail interface in python is "if you didn't get an exception, it's a success".  This is fairly heavily applied in the dcos-cli code in dcos.http where all non-200 http responses will result in an exception.  Therefore it's pretty reasonable to just accept any response value without an exception as the desired result.