### PR TITLE
[SPARK-461] change get_task to get_tasks

### DIFF
--- a/shakedown/dcos/task.py
+++ b/shakedown/dcos/task.py
@@ -66,7 +66,7 @@ def task_completed(task_id):
         :rtype: bool
     """
 
-    tasks = get_task(task_id=task_id)
+    tasks = get_tasks(task_id=task_id)
     completed_states = ('TASK_FINISHED',
                         'TASK_FAILED',
                         'TASK_KILLED',


### PR DESCRIPTION
Fixes the following exception:

```python
for task in tasks:
    if task['state'] in completed_states:
    TypeError: string indices must be integers
```