### PR TITLE
Changed wait_for_task_completion() to use time_wait()

### DIFF
--- a/shakedown/dcos/spinner.py
+++ b/shakedown/dcos/spinner.py
@@ -140,6 +140,8 @@ def pretty_duration(seconds):
     """ Returns a user-friendly representation of the provided duration in seconds.
     For example: 62.8 => "1m2.8s", or 129837.8 => "2d12h4m57.8s"
     """
+    if seconds is None:
+        return ''
     ret = ''
     if seconds >= 86400:
         ret += '{:.0f}d'.format(int(seconds / 86400))

--- a/shakedown/dcos/task.py
+++ b/shakedown/dcos/task.py
@@ -80,7 +80,7 @@ def task_completed(task_id):
     return False
 
 
-def wait_for_task_completion(task_id):
+def wait_for_task_completion(task_id, timeout_sec=None):
     """ Block until the task completes
 
         :param task_id: task ID
@@ -88,8 +88,7 @@ def wait_for_task_completion(task_id):
 
         :rtype: None
     """
-    while not task_completed(task_id):
-        time.sleep(1)
+    return time_wait(lambda: task_completed(task_id), timeout_seconds=timeout_sec)
 
 
 def task_property_value_predicate(service, task, prop, value):


### PR DESCRIPTION
Before this change, wait_for_task_completion() would return if any transient HTTP exception was encountered. This behavior was inconsistent with the other wait_for_task* methods.

This PR uses the time_wait() helper function in wait_for_task_completion(), and adds a timeout parameter. This changes the behavior if an exception is thrown, because by default time_wait() ignores exceptions and retries until the timeout expires.