### PR TITLE
Don't wait for things to pass twice before returning

### DIFF
--- a/shakedown/dcos/spinner.py
+++ b/shakedown/dcos/spinner.py
@@ -39,7 +39,7 @@ def wait_for(
         else:
             if (not inverse_predicate and result) or (inverse_predicate and not result):
                 count = count + 1
-            if count > required_consecutive_success_count:
+            if count >= required_consecutive_success_count:
                 return result
 
         if timeout.is_expired():


### PR DESCRIPTION
```
》[1m1.9s/10m] spinning...
expected 3 tasks in TASK_RUNNING:
- 3 in expected TASK_RUNNING: kafka-2-broker, kafka-1-broker, kafka-0-broker
- 0 in other states: 
》[1m3.7s/10m] spinning...
expected 3 tasks in TASK_RUNNING:
- 3 in expected TASK_RUNNING: kafka-2-broker, kafka-1-broker, kafka-0-broker
- 0 in other states: 
》[0.2s/10m] spinning...

》install completed after 1m9.4s
```