### PR TITLE
Don't output exception if trying to attach

### DIFF
--- a/shakedown/dcos/__init__.py
+++ b/shakedown/dcos/__init__.py
@@ -1,6 +1,7 @@
 import os
 import dcos
 import dcos.cluster
+import sys
 
 import shakedown
 
@@ -9,7 +10,8 @@ def attach_cluster(url):
     """Attach to an already set-up cluster
     :return: True if successful, else False
     """
-    clusters = [c.dict() for c in dcos.cluster.get_clusters()]
+    with shakedown.stdchannel_redirected(sys.stderr, os.devnull):
+        clusters = [c.dict() for c in dcos.cluster.get_clusters()]
     for c in clusters:
         if url == c['url']:
             try:


### PR DESCRIPTION
except silently and continue attachment attempts if a previously set-up
cluster is no longer reachable.