### PR TITLE
Add ability to retrieve Docker version(s)

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,6 +59,9 @@
       * [run_command_on_agent()](#run_command_on_agent)
       * [run_dcos_command()](#run_dcos_command)
     * Docker
+      * [docker_version()](#docker_version)
+      * [docker_server_version()](#docker_server_version)
+      * [docker_client_version()](#docker_client_version)
       * [create_docker_credentials_file()](#create_docker_credentials_file)
       * [distribute_docker_credentials_to_private_agents()](#distribute_docker_credentials_to_private_agents)
       * [prefetch_docker_image_on_private_agents()](#prefetch_docker_image_on_private_agents)
@@ -1059,6 +1062,61 @@ parameter | description | type | default
 stdout, stderr, return_code = run_dcos_command('package search jenkins --json')
 result_json = json.loads(stdout)
 print(result_json['packages'][0]['currentVersion'])
+```
+
+
+### docker_version()
+
+Get the version of Docker [Server]
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+component | which Docker version component to query (`server` or `client`) | str | `server`
+
+##### *example usage*
+
+```python
+master_docker_version = docker_version()
+print("DC/OS master is running Docker version {}".format(master_docker_version))
+```
+
+
+### docker_server_version()
+
+Get the version of Docker Server
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+
+##### *example usage*
+
+```python
+docker_server = docker_server_version()
+print("DC/OS master is running Docker Server version {}".format(docker_server))
+```
+
+
+### docker_client_version()
+
+Get the version of Docker Client
+
+##### *parameters*
+
+parameter | description | type | default
+--------- | ----------- | ---- | -------
+host | host or IP of the machine Docker is running on | str | `master_ip()`
+
+##### *example usage*
+
+```python
+docker_client = docker_client_version()
+print("DC/OS master is running Docker Client version {}".format(docker_client))
 ```
 
 

--- a/shakedown/dcos/docker.py
+++ b/shakedown/dcos/docker.py
@@ -9,6 +9,58 @@ import shakedown
 from dcos import marathon
 
 
+def docker_version(host=None, component='server'):
+    """ Return the version of Docker [Server]
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :param component: Docker component
+        :type component: str
+        :return: Docker version
+        :rtype: str
+    """
+
+    if component.lower() == 'client':
+        component = 'Client'
+    else:
+        component = 'Server'
+
+    # sudo is required for non-coreOS installs
+    command = 'sudo docker version -f {{.{}.Version}}'.format(component)
+
+    if host is None:
+        success, output = shakedown.run_command_on_master(command, None, None, False)
+    else:
+        success, output = shakedown.run_command_on_host(host, command, None, None, False)
+
+    if success:
+        return output
+    else:
+        return 'unknown'
+
+
+def docker_client_version(host):
+    """ Return the version of Docker Client
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :return: Docker Client version
+        :rtype: str
+    """
+    return docker_version('{{.Client.Version}}')
+
+
+def docker_server_version(host):
+    """ Return the version of Docker Server
+
+        :param host: host or IP of the machine Docker is running on
+        :type host: str
+        :return: Docker Server version
+        :rtype: str
+    """
+    return docker_version('{{.Server.Version}}')
+
+
 def create_docker_credentials_file(
         username,
         password,

--- a/tests/acceptance/test_dcos_docker.py
+++ b/tests/acceptance/test_dcos_docker.py
@@ -1,0 +1,6 @@
+from shakedown import *
+
+def test_docker_version():
+    master_docker_version = docker_version()
+    print("DC/OS master is running Docker Server {}".format(master_docker_version))
+    assert master_docker_version != 'unknown'


### PR DESCRIPTION
New methods:

 - `docker_version()`
 - `docker_client_version()`
 - `docker_server_version()`

default behavior is to query the master for this information, but
methods support host specification.