### PR TITLE
fuzz resource numbers in test assertation

### DIFF
--- a/tests/acceptance/test_dcos_cluster.py
+++ b/tests/acceptance/test_dcos_cluster.py
@@ -20,8 +20,8 @@ def test_get_used_resources():
 
 def test_get_reserved_resources():
     resources = get_reserved_resources()
-    assert resources.cpus == 4
-    assert resources.mem == 14021.0
+    assert resources.cpus > 0
+    assert resources.mem > 0
 
 
 def test_resources_needed():


### PR DESCRIPTION
per @kensipe, these were originally assuming clusters with nodes of very
specific sizes, which is no longer the case