### PR TITLE
Handle skip state when printing out stdout/stderr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-dcoscli==0.5.5
+dcoscli==0.5.7
 paramiko
 pytest
 pytest-timeout

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='dcos-shakedown',
       zip_safe=False,
       install_requires=[
           'click',
-          'dcoscli==0.5.5',
+          'dcoscli==0.5.7',
           'paramiko',
           'pytest',
           'pytest-timeout',

--- a/shakedown/cli/helpers.py
+++ b/shakedown/cli/helpers.py
@@ -67,6 +67,7 @@ def fchr(char):
     return {
         'PP': chr(10003),
         'FF': chr(10005),
+        'SK': chr(10073),
         '>>': chr(12299)
     }.get(char, '')
 

--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -181,6 +181,8 @@ def cli(**args):
                 schr = fchr('FF')
             elif state == 'pass':
                 schr = fchr('PP')
+            else
+                schr = ''
 
             if status:
                 if not args['stdout_inline']:

--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -181,7 +181,7 @@ def cli(**args):
                 schr = fchr('FF')
             elif state == 'pass':
                 schr = fchr('PP')
-            else
+            else:
                 schr = ''
 
             if status:

--- a/shakedown/cli/main.py
+++ b/shakedown/cli/main.py
@@ -181,6 +181,8 @@ def cli(**args):
                 schr = fchr('FF')
             elif state == 'pass':
                 schr = fchr('PP')
+            elif state == 'skip':
+                schr = fchr('SK')
             else:
                 schr = ''
 


### PR DESCRIPTION
I have seen this error in our SI tests. I believe it is caused by not handling "skipped" state properly in one of the methods.

```
INTERNALERROR> 
INTERNALERROR> self = <shakedown.cli.main.cli.<locals>.shakedown object at 0x7fc697aae320>
INTERNALERROR> report = <TestReport 'tests/system/test_marathon_root.py::test_marathon_backup_and_restore_leader' when='setup' outcome='skipped'>
INTERNALERROR> 
INTERNALERROR>     def pytest_runtest_logreport(self, report):
INTERNALERROR>         """ Log the [stdout, stderr] results of tests if desired
INTERNALERROR>                 """
INTERNALERROR>     
INTERNALERROR>         state = None
INTERNALERROR>     
INTERNALERROR>         for secname, content in report.sections:
INTERNALERROR>             if report.failed:
INTERNALERROR>                 state = 'fail'
INTERNALERROR>             if report.passed:
INTERNALERROR>                 state = 'pass'
INTERNALERROR>             if report.skipped:
INTERNALERROR>                 state = 'skip'
INTERNALERROR>     
INTERNALERROR>             if state and secname != 'Captured stdout call':
INTERNALERROR>                 module = report.nodeid.split('::', 1)[0]
INTERNALERROR>                 cap_type = secname.split(' ')[-1]
INTERNALERROR>     
INTERNALERROR>                 if not 'setup' in shakedown.tests['test'][report.nodeid]:
INTERNALERROR>                     shakedown.tests['test'][report.nodeid]['setup'] = True
INTERNALERROR> >                   shakedown.output(module + ' ' + cap_type, state, content, False)
INTERNALERROR> 
INTERNALERROR> /usr/lib/python3.6/site-packages/shakedown/cli/main.py:299: 
INTERNALERROR> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
INTERNALERROR> 
INTERNALERROR> title = 'tests/system/test_marathon_root.py setup', state = 'skip'
INTERNALERROR> text = "http.py                    134 INFO     Sending HTTP ['get'] to ['http://34.216.5.72//exhibitor/exhibitor/v1/explorer...': 'chunked', 'Connection': 'keep-alive'}\nutil.py                    565 DEBUG    duration: dcos.http._request: 0.02s"
INTERNALERROR> status = False
INTERNALERROR> 
INTERNALERROR>     def output(title, state, text, status=True):
INTERNALERROR>         """ Capture and display stdout/stderr output
INTERNALERROR>     
INTERNALERROR>                     :param title: the title of the output box (eg. test name)
INTERNALERROR>                     :type title: str
INTERNALERROR>                     :param state: state of the result (pass, fail)
INTERNALERROR>                     :type state: str
INTERNALERROR>                     :param text: the stdout/stderr output
INTERNALERROR>                     :type text: str
INTERNALERROR>                     :param status: whether to output a status marker
INTERNALERROR>                     :type status: bool
INTERNALERROR>                 """
INTERNALERROR>         if state == 'fail':
INTERNALERROR>             schr = fchr('FF')
INTERNALERROR>         elif state == 'pass':
INTERNALERROR>             schr = fchr('PP')
INTERNALERROR>     
INTERNALERROR>         if status:
INTERNALERROR>             if not args['stdout_inline']:
INTERNALERROR>                 if state == 'fail':
INTERNALERROR>                     echo(schr, d='fail')
INTERNALERROR>                 elif state == 'pass':
INTERNALERROR>                     echo(schr, d='pass')
INTERNALERROR>             else:
INTERNALERROR>                 if not text:
INTERNALERROR>                     if state == 'fail':
INTERNALERROR>                         echo(schr, d='fail')
INTERNALERROR>                     elif state == 'pass':
INTERNALERROR>                         if '::' in title:
INTERNALERROR>                             echo(title.split('::')[-1], d='item-min', n=False)
INTERNALERROR>                         echo(schr, d='pass')
INTERNALERROR>     
INTERNALERROR>         if text and args['stdout'] in [state, 'all']:
INTERNALERROR> >           o = decorate(schr + ': ', 'quote-head-' + state)
INTERNALERROR> E           UnboundLocalError: local variable 'schr' referenced before assignment
INTERNALERROR> 
INTERNALERROR> /usr/lib/python3.6/site-packages/shakedown/cli/main.py:201: UnboundLocalError
```

JIRA: MARATHON-7957