### PR TITLE
Only try to pull IP information from the TASK_RUNNING status

### DIFF
--- a/shakedown/dcos/service.py
+++ b/shakedown/dcos/service.py
@@ -207,8 +207,13 @@ def get_service_ips(
 
     for task in service_tasks:
         if task_name is None or task['name'] == task_name:
-            for ip in task['statuses'][0]['container_status']['network_infos'][0]['ip_addresses']:
-                ips.add(ip['ip_address'])
+            for status in task['statuses']:
+                # Only the TASK_RUNNING status will have correct IP information.
+                if status["state"] != "TASK_RUNNING":
+                    continue
+
+                for ip in status['container_status']['network_infos'][0]['ip_addresses']:
+                    ips.add(ip['ip_address'])
 
     return ips
 


### PR DESCRIPTION
I've been debugging some tests of ours that rely on shakedown's `get_service_ips` function. That function has signature, `get_service_ips(service_name, task_name)`

That function has previously _always_ assumed that the _first_ status for a task in mesos state would have `network_infos` under `container_status`.:
https://github.com/dcos/shakedown/blob/master/shakedown/dcos/service.py#L210

However, that is no longer true in 1.11-dev as I'm seeing the TASK_STARTING status left behind after the TASK_RUNNING status is stored.

```"statuses": [{
                            "state": "TASK_STARTING",
                            "timestamp": 1512948747.0366,
                            "container_status": {
                                "container_id": {
                                    "value": "4dce28a9-65b7-42d6-9431-48edc148099f",
                                    "parent": {
                                        "value": "de646a4f-cca2-457a-8d84-23e522d51cff"
                                    }
                                }
                            }
                        },
                        {
                            "state": "TASK_RUNNING",
                            "timestamp": 1512948797.1611,
                            "container_status": {
                                "container_id": {
                                    "value": "4dce28a9-65b7-42d6-9431-48edc148099f",
                                    "parent": {
                                        "value": "de646a4f-cca2-457a-8d84-23e522d51cff"
                                    }
                                },
                                "network_infos": [{
                                    "ip_addresses": [{
                                        "protocol": "IPv4",
                                        "ip_address": "10.0.1.24"
                                    }]
                                }]
                            }
                        }
                    ],```

Submitting PR while waiting to hear back from Mesos if this is expected.